### PR TITLE
Widget initialization fix

### DIFF
--- a/src/DynamicFormWidget.php
+++ b/src/DynamicFormWidget.php
@@ -217,8 +217,10 @@ class DynamicFormWidget extends \yii\base\Widget
         $js .= "});\n";
         $view->registerJs($js, $view::POS_READY);
 
-        $js = 'jQuery("#' . $this->formId . '").on(\'afterInit\', function () {jQuery("#' . $this->formId . '").yiiDynamicForm(' . $this->_hashVar .');});' . "\n";
-        $view->registerJs($js, $view::POS_LOAD);
+        $js = 'jQuery(document).ready(function() {' . "\n";
+        $js .= '    jQuery("#' . $this->formId . '").yiiDynamicForm(' . $this->_hashVar .');' . "\n";
+        $js .= '});' . "\n";
+        $view->registerJs($js, $view::POS_READY);
     }
 
     /**


### PR DESCRIPTION
The previous fix related to [Uncaught TypeError: Cannot read property 'settings' of undefined & $toclone.clone is not a function](https://github.com/wbraganca/yii2-dynamicform/issues/224) required changes due to a widget initialization bug in Opera and Firefox browsers. 

The following lines have been changed:

```
$js = 'jQuery("#' . $this->formId . '").on(\'afterInit\', function () {jQuery("#' . $this->formId . '").yiiDynamicForm(' . $this->_hashVar .');});' . "\n";
$view->registerJs($js, $view::POS_LOAD);
```
to 
```
$js = 'jQuery(document).ready(function() {' . "\n";
$js .= '    jQuery("#' . $this->formId . '").yiiDynamicForm(' . $this->_hashVar .');' . "\n";
$js .= '});' . "\n";
$view->registerJs($js, $view::POS_READY);
```